### PR TITLE
Change sideloader deploy for docker use

### DIFF
--- a/.deploy.yaml
+++ b/.deploy.yaml
@@ -1,6 +1,6 @@
 buildscript: scripts/build.sh
 postinstall: scripts/postinstall.sh
 dependencies:
- - lxc-docker
+ - docker-engine
 pip:
  - docker-compose


### PR DESCRIPTION
The current sideloader deploy is for deploying it the usual way. This needs to be changed to just copy this repository over, so that mama-ng-deploy can create and run the Docker image from this repository.
